### PR TITLE
Add configurable `securityContext` at the Pod and Container level for `ciroos-agents` chart

### DIFF
--- a/charts/ciroos-agents/Chart.yaml
+++ b/charts/ciroos-agents/Chart.yaml
@@ -4,6 +4,6 @@ description: Deploys the Ciroos observability agent into your Kubernetes cluster
 
 type: application
 
-version: 0.3.2
+version: 0.3.3
 
 appVersion: "0.3.0"

--- a/charts/ciroos-agents/templates/daemonset.yaml
+++ b/charts/ciroos-agents/templates/daemonset.yaml
@@ -31,27 +31,33 @@ spec:
         resources: {{- toYaml .Values.ebpfTopoColl.ebpfTopoColl.resources | nindent 10
           }}
         securityContext:
-          runAsUser: 0
-          runAsGroup: 0
+        {{- if (not .Values.ebpfTopoColl.ebpfTopoColl.containerSecurityContext) }}
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           capabilities:
-            add:
-              {{- if .Values.ebpfTopoColl.ebpfTopoColl.useSysAdminCap }}
-              - SYS_ADMIN
-              {{- else }}
-              - BPF
-              - PERFMON
-              {{- end }}
-              - NET_ADMIN
-              - SYS_RESOURCE
             drop:
               - ALL
+            add:
+              - NET_ADMIN
+              - SYS_RESOURCE
+          {{- if .Values.ebpfTopoColl.ebpfTopoColl.useSysAdminCap }}
+              - SYS_ADMIN
+          {{- else }}
+              - BPF
+              - PERFMON
+          {{- end }}
+        {{- else }}
+          {{- toYaml .Values.ebpfTopoColl.ebpfTopoColl.containerSecurityContext
+            | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - mountPath: /sys/fs/cgroup
           name: cgroup
           readOnly: true
-      hostPID: true
       imagePullSecrets:
       - name: regcred
+      securityContext: {{- toYaml .Values.ebpfTopoColl.podSecurityContext | nindent
+        8 }}
       volumes:
       - hostPath:
           path: /sys/fs/cgroup
@@ -106,6 +112,8 @@ spec:
         image: {{ .Values.otelCollector.otelCollector.image.repository }}:{{ .Values.otelCollector.otelCollector.image.tag
           | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.otelCollector.otelCollector.imagePullPolicy }}
+        securityContext: {{- toYaml .Values.otelCollector.otelCollector.containerSecurityContext
+          | nindent 10 }}
         name: otel-collector
         ports:
         - containerPort: 8888
@@ -118,6 +126,8 @@ spec:
           subPath: config.yaml
       imagePullSecrets:
       - name: regcred
+      securityContext: {{- toYaml .Values.otelCollector.podSecurityContext | nindent
+        8 }}
       volumes:
       - configMap:
           defaultMode: 420

--- a/charts/ciroos-agents/templates/deployment.yaml
+++ b/charts/ciroos-agents/templates/deployment.yaml
@@ -64,6 +64,8 @@ spec:
         image: {{ .Values.beacon.beacon.image.repository }}:{{ .Values.beacon.beacon.image.tag
           | default .Chart.AppVersion }}
         imagePullPolicy: IfNotPresent
+        securityContext: {{- toYaml .Values.beacon.beacon.containerSecurityContext
+          | nindent 10 }}
         name: beacon
         resources: {{- toYaml .Values.beacon.beacon.resources | nindent 10 }}
         volumeMounts:
@@ -72,6 +74,8 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: regcred
+      securityContext: {{- toYaml .Values.beacon.podSecurityContext | nindent
+        8 }}
       serviceAccountName: beacon-sa
       volumes:
       - name: ciroos-agent-cert
@@ -122,6 +126,8 @@ spec:
         image: {{ .Values.ebpfTopoReducer.ebpfTopoReducer.image.repository }}:{{ .Values.ebpfTopoReducer.ebpfTopoReducer.image.tag
           | default .Chart.AppVersion }}
         imagePullPolicy: IfNotPresent
+        securityContext: {{- toYaml .Values.ebpfTopoReducer.ebpfTopoReducer.containerSecurityContext
+          | nindent 10 }}
         name: ebpf-topo-reducer
         resources: {{- toYaml .Values.ebpfTopoReducer.ebpfTopoReducer.resources | nindent
           10 }}
@@ -131,6 +137,8 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: regcred
+      securityContext: {{- toYaml .Values.ebpfTopoReducer.podSecurityContext | nindent
+        8 }}
       serviceAccountName: ebpf-topo-reducer
       terminationGracePeriodSeconds: 30
       volumes:
@@ -279,6 +287,7 @@ spec:
         image: '{{ .Values.sourceRepositoryWatcherController.controller.image.repository
           }}:{{ .Values.sourceRepositoryWatcherController.controller.image.tag | default
           .Chart.AppVersion }}'
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
             path: /healthz
@@ -316,11 +325,13 @@ kind: Deployment
 metadata:
   name: vector
   labels:
+    app: vector
   {{- include "ciroos-agents.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.vector.replicas }}
   selector:
     matchLabels:
+      app: vector
       app.kubernetes.io/component: Agent
       app.kubernetes.io/instance: vector
       app.kubernetes.io/name: vector
@@ -328,6 +339,7 @@ spec:
   template:
     metadata:
       labels:
+        app: vector
         app.kubernetes.io/component: Agent
         app.kubernetes.io/instance: vector
         app.kubernetes.io/name: vector
@@ -373,6 +385,8 @@ spec:
         image: {{ .Values.vector.vector.image.repository }}:{{ .Values.vector.vector.image.tag
           | default .Chart.AppVersion }}
         imagePullPolicy: IfNotPresent
+        securityContext: {{- toYaml .Values.vector.vector.containerSecurityContext
+          | nindent 10 }}
         name: vector
         ports:
         - containerPort: 9090
@@ -390,6 +404,8 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: regcred
+      securityContext: {{- toYaml .Values.vector.podSecurityContext | nindent
+        8 }}
       serviceAccountName: vector
       terminationGracePeriodSeconds: 60
       volumes:

--- a/charts/ciroos-agents/templates/vector.yaml
+++ b/charts/ciroos-agents/templates/vector.yaml
@@ -7,7 +7,7 @@ metadata:
   {{- include "ciroos-agents.labels" . | nindent 4 }}
 data:
   agent.yaml: |
-    data_dir: /tmp/vector
+    data_dir: /vector-data-dir/vector
     sources:
       k8s_events_source:
         type: http_server

--- a/charts/ciroos-agents/values.yaml
+++ b/charts/ciroos-agents/values.yaml
@@ -20,12 +20,24 @@ beacon:
       requests:
         cpu: 100m
         memory: 256Mi
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      readOnlyRootFilesystem: true
   replicas: 1
+  podSecurityContext:
+    fsGroup: 1000
+    runAsGroup: 1000
+    runAsNonRoot: true
+    runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault
 beaconSa:
   serviceAccount:
     annotations: {}
 ebpfTopoColl:
-  enabled: true
   ebpfTopoColl:
     useSysAdminCap: false
     image:
@@ -38,6 +50,15 @@ ebpfTopoColl:
       requests:
         cpu: 100m
         memory: 128Mi
+    containerSecurityContext:
+  enabled: true
+  podSecurityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+    runAsNonRoot: true
+    seccompProfile:
+      type: Unconfined  # eBPF requires bpf() and perf_event_open() syscalls blocked by RuntimeDefault
 ebpfTopoReducer:
   ebpfTopoReducer:
     image:
@@ -50,17 +71,24 @@ ebpfTopoReducer:
       requests:
         cpu: 500m
         memory: 256Mi
-  replicas: 1
-  serviceAccount:
-    annotations: {}
-eventrouterController:
-  controller:
     containerSecurityContext:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
           - ALL
       readOnlyRootFilesystem: true
+  replicas: 1
+  serviceAccount:
+    annotations: {}
+  podSecurityContext:
+    fsGroup: 1000
+    runAsGroup: 1000
+    runAsNonRoot: true
+    runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault
+eventrouterController:
+  controller:
     image:
       repository: registry.ciroos.ai/netra/eventrouter-controller
       tag: 06ccc0002-17f5206e7-260327T1049Z
@@ -71,8 +99,17 @@ eventrouterController:
       requests:
         cpu: 250m
         memory: 512Mi
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      readOnlyRootFilesystem: true
   podSecurityContext:
+    fsGroup: 1000
+    runAsGroup: 1000
     runAsNonRoot: true
+    runAsUser: 1000
     seccompProfile:
       type: RuntimeDefault
   serviceAccount:
@@ -84,7 +121,6 @@ eventrouterGvks:
   heartbeatUrl: http://vector-service:8997/k8s/heartbeat
 kubernetesClusterDomain: cluster.local
 otelCollector:
-  enabled: true
   otelCollector:
     image:
       repository: registry.ciroos.ai/netra/otelcollector
@@ -96,15 +132,22 @@ otelCollector:
       requests:
         cpu: 100m
         memory: 128Mi
-sourceRepositoryWatcherController:
-  enabled: true
-  controller:
     containerSecurityContext:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
           - ALL
       readOnlyRootFilesystem: true
+  enabled: true
+  podSecurityContext:
+    fsGroup: 1000
+    runAsGroup: 1000
+    runAsNonRoot: true
+    runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault
+sourceRepositoryWatcherController:
+  controller:
     image:
       repository: registry.ciroos.ai/netra/source-repository-watcher
       tag: 7930def4b-49f4b2ec4-260227T1741Z
@@ -115,17 +158,24 @@ sourceRepositoryWatcherController:
       requests:
         cpu: 100m
         memory: 128Mi
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      readOnlyRootFilesystem: true
+  enabled: true
+  replicas: 1
+  serviceAccount:
+    annotations: {}
   podSecurityContext:
+    fsGroup: 1000
+    runAsGroup: 1000
     runAsNonRoot: true
+    runAsUser: 1000
     seccompProfile:
       type: RuntimeDefault
-  replicas: 1
-  serviceAccount:
-    annotations: {}
 vector:
-  replicas: 1
-  serviceAccount:
-    annotations: {}
   vector:
     env:
       rustBacktrace: full
@@ -140,3 +190,19 @@ vector:
       requests:
         cpu: "1"
         memory: 512Mi
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      readOnlyRootFilesystem: true
+  replicas: 1
+  serviceAccount:
+    annotations: {}
+  podSecurityContext:
+    fsGroup: 1000
+    runAsGroup: 1000
+    runAsNonRoot: true
+    runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault


### PR DESCRIPTION
## Description

Add configurable `securityContext` at the Pod and Container level for `ciroos-agents` chart. For `ebpf-topo-coll` Daemonset, set `secCompProfile` to `Unconfined` for loading ebpf programs and handle relevant flag 'useSysAdminCap'. Pass default securityContexts for all but `ebpf-topo-coll` Daemonset, which is conditionally set in the chart itself.

## Tests

* `helm lint`
```
==> Linting charts/ciroos-agents
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed
```

* `helm install ciroos charts/ciroos-agents --create-namespace -n ciroos-agent  -f ~/gaurav-mac-kind-default.values`
```
NAME    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
ciroos  ciroos-agent    1               2026-04-08 14:27:59.420009 -0700 PDT    deployed        ciroos-agents-0.3.3     0.3.0
```

Addresses https://github.com/ciroos-ai/netra/issues/385

--
**PS**: The change maps what's [proposed](https://github.com/ciroos-ai/gitops/pull/1780/changes) in `gitops` repo.