### PR TITLE
Add more capabilities for ebpf-topo-collector read permissions.

### DIFF
--- a/charts/ciroos-agents/Chart.yaml
+++ b/charts/ciroos-agents/Chart.yaml
@@ -4,6 +4,6 @@ description: Deploys the Ciroos observability agent into your Kubernetes cluster
 
 type: application
 
-version: 0.3.3
+version: 0.3.4
 
 appVersion: "0.3.0"

--- a/charts/ciroos-agents/templates/daemonset.yaml
+++ b/charts/ciroos-agents/templates/daemonset.yaml
@@ -40,6 +40,8 @@ spec:
             add:
               - NET_ADMIN
               - SYS_RESOURCE
+              - SYS_PTRACE
+              - DAC_READ_SEARCH
           {{- if .Values.ebpfTopoColl.ebpfTopoColl.useSysAdminCap }}
               - SYS_ADMIN
           {{- else }}


### PR DESCRIPTION
## Description

Add more capabilities for `ebpf-topo-collector` read permissions.

This is partial fix to the missing permission issues. Part of the fix lies in how the container image is created. This was required for effective capabilities to take into effect.

## Test

* helm lint successful
* 