### PR TITLE
Update ebpf-topo-coll image tag to use the lates image.

### DIFF
--- a/charts/ciroos-agents/Chart.yaml
+++ b/charts/ciroos-agents/Chart.yaml
@@ -4,6 +4,6 @@ description: Deploys the Ciroos observability agent into your Kubernetes cluster
 
 type: application
 
-version: 0.3.4
+version: 0.3.5
 
 appVersion: "0.3.0"

--- a/charts/ciroos-agents/values.yaml
+++ b/charts/ciroos-agents/values.yaml
@@ -42,7 +42,7 @@ ebpfTopoColl:
     useSysAdminCap: false
     image:
       repository: registry.ciroos.ai/netra/ebpf-topo-coll
-      tag: e0299ca08-52618fe41-260225T1856Z
+      tag: 530d845b6-2b36b3d8e-260417T1439Z
     resources:
       limits:
         cpu: 250m


### PR DESCRIPTION
## Description

Update `ebpf-topo-coll` image tag to use the lates image.

## Testing

1. `helm lint` works
2. `helm upgrade --install ciroos-agent charts/ciroos-agents/ --create-namespace -n ciroos-agent -f /tmp/gaurav-dev.yaml` upgraded to the latest image.