### PR TITLE
Un-managed helm chart update

### DIFF
--- a/charts/ciroos-agents/Chart.yaml
+++ b/charts/ciroos-agents/Chart.yaml
@@ -4,6 +4,6 @@ description: Deploys the Ciroos observability agent into your Kubernetes cluster
 
 type: application
 
-version: 0.3.4
+version: 0.3.5
 
 appVersion: "0.3.0"

--- a/charts/ciroos-agents/templates/beacon-clusterrole-rbac.yaml
+++ b/charts/ciroos-agents/templates/beacon-clusterrole-rbac.yaml
@@ -24,6 +24,18 @@ rules:
   - get
   - list
   - watch
+{{- if .Values.beacon.impersonate }}
+- apiGroups:
+  - ""
+  resources:
+  - "serviceaccounts"
+  verbs:
+  - "impersonate"
+  {{- if .Values.beacon.impersonatedServiceAccounts }}
+  resourceNames:
+    {{- toYaml .Values.beacon.impersonatedServiceAccounts | nindent 4 }}
+  {{- end }}
+{{- end }}
 {{- else }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -50,4 +62,16 @@ rules:
   - get
   - list
   - watch
+{{- if .Values.beacon.impersonate }}
+- apiGroups:
+  - ""
+  resources:
+  - "serviceaccounts"
+  verbs:
+  - "impersonate"
+  {{- if .Values.beacon.impersonatedServiceAccounts }}
+  resourceNames:
+    {{- toYaml .Values.beacon.impersonatedServiceAccounts | nindent 4 }}
+  {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/ciroos-agents/templates/daemonset.yaml
+++ b/charts/ciroos-agents/templates/daemonset.yaml
@@ -86,7 +86,10 @@ spec:
       {{- include "ciroos-agents.selectorLabels" . | nindent 8 }}
     spec:
       containers:
-      - env:
+      - args:
+        - --config
+        - /etc/otel/config.yaml
+        env:
         - name: K8S_NODE_IP
           valueFrom:
             fieldRef:

--- a/charts/ciroos-agents/templates/otel-collector-config.yaml
+++ b/charts/ciroos-agents/templates/otel-collector-config.yaml
@@ -93,7 +93,7 @@ data:
         passthrough: false
         filter:
           # only retrieve pods running on the same node as the collector
-          node_from_env_var: KUBE_NODE_NAME
+          node_from_env_var: K8S_NODE_NAME
         extract:
           # The attributes provided in 'metadata' will be added to associated resources
           metadata:

--- a/charts/ciroos-agents/values.yaml
+++ b/charts/ciroos-agents/values.yaml
@@ -1,6 +1,6 @@
 namespaceScoped: false
 clusterNamespace: ""
-clusterName: "cluster-name"
+clusterName: ""
 ingressFqdn: ""
 ciroosIngressUrl: ""
 ciroosDockerconfigjson: ""
@@ -12,7 +12,7 @@ beacon:
   beacon:
     image:
       repository: registry.ciroos.ai/netra/beacon
-      tag: 00d48859a-a19e43704-260419T1826Z
+      tag: d5f02432f-013b59ff0-260427T2309Z
     resources:
       limits:
         cpu: 250m
@@ -34,6 +34,8 @@ beacon:
     runAsUser: 1000
     seccompProfile:
       type: RuntimeDefault
+  impersonate: false
+  impersonatedServiceAccounts: []
 beaconSa:
   serviceAccount:
     annotations: {}
@@ -42,7 +44,7 @@ ebpfTopoColl:
     useSysAdminCap: false
     image:
       repository: registry.ciroos.ai/netra/ebpf-topo-coll
-      tag: fb8ab271e-d3468a69c-260418T1709Z
+      tag: fe83ce5c0-1a0ab3e12-260421T1423Z
     resources:
       limits:
         cpu: 250m
@@ -63,7 +65,7 @@ ebpfTopoReducer:
   ebpfTopoReducer:
     image:
       repository: registry.ciroos.ai/netra/ebpf-topo-reducer
-      tag: cb1a6d6d0-2b36b3d8e-260417T1439Z
+      tag: 85e0098b8-f8e66495e-260421T1147Z
     resources:
       limits:
         cpu: "1"
@@ -91,7 +93,7 @@ eventrouterController:
   controller:
     image:
       repository: registry.ciroos.ai/netra/eventrouter-controller
-      tag: 2f356b608-2b36b3d8e-260417T1439Z
+      tag: edc60e52f-20ffd2832-260428T1548Z
     resources:
       limits:
         cpu: 500m
@@ -124,7 +126,7 @@ otelCollector:
   otelCollector:
     image:
       repository: registry.ciroos.ai/netra/otelcollector
-      tag: b980b4df3-2b36b3d8e-260417T1439Z
+      tag: 04331d0fa-f8e66495e-260421T1147Z
     resources:
       limits:
         cpu: 250m
@@ -150,7 +152,7 @@ sourceRepositoryWatcherController:
   controller:
     image:
       repository: registry.ciroos.ai/netra/source-repository-watcher
-      tag: 34c1f5cc4-2b36b3d8e-260417T1439Z
+      tag: 09057bf3b-f8e66495e-260421T1147Z
     resources:
       limits:
         cpu: 500m
@@ -182,7 +184,7 @@ vector:
       vectorLog: info
     image:
       repository: registry.ciroos.ai/netra/vector
-      tag: cc08f82c7-2b36b3d8e-260417T1439Z
+      tag: caf9d71cd-f8e66495e-260421T1147Z
     resources:
       limits:
         cpu: "2"


### PR DESCRIPTION
This new version updates images for all Ciroos agents and some configurations.

It also adds support for beacon impersonate feature. Two new helm values are exposed:
- beacon.impersonate: defaults to false. when set to true, beacon gets granted permission to impersonate ServiceAccounts.
- beacon.impersonatedServiceAccounts: when beacon.impersonate is set to true, beacon by default is granted permissions any ServiceAccount. Setting this will limit the ServiceAccounts that beacon can impersonate