### PR TITLE
Ciroos Helm chart: extend sveltos-applier RBAC

### DIFF
--- a/charts/ciroos/Chart.yaml
+++ b/charts/ciroos/Chart.yaml
@@ -4,6 +4,6 @@ description: Deploys Sveltos applier with pre-generated cluster-specific configu
 
 type: application
 
-version: 0.2.5
+version: 0.3.0
 
-appVersion: "0.2.0"
+appVersion: "0.3.0"

--- a/charts/ciroos/templates/sveltos-applier-manager-other-roles-rbac.yaml
+++ b/charts/ciroos/templates/sveltos-applier-manager-other-roles-rbac.yaml
@@ -24,6 +24,7 @@ rules:
   - watch
 - apiGroups:
   - ""
+  - events.k8s.io
   resources:
   - events
   verbs:


### PR DESCRIPTION
This grants events.events.k8s.io write permissions. Those are required by:

1. Insight (new component)
2. Newer version of Sveltos (we are at v1.6.0 and have not advanced because Sveltos has switched to events.events.k8s.io given corev1 Events are now deprecrated)