### PR TITLE
ciroos-agents: update the chart for ebpf-topo-coll service.

### DIFF
--- a/charts/ciroos-agents/Chart.yaml
+++ b/charts/ciroos-agents/Chart.yaml
@@ -4,6 +4,6 @@ description: Deploys the Ciroos observability agent into your Kubernetes cluster
 
 type: application
 
-version: 0.3.7
+version: 0.3.8
 
 appVersion: "0.3.0"

--- a/charts/ciroos-agents/templates/daemonset.yaml
+++ b/charts/ciroos-agents/templates/daemonset.yaml
@@ -33,21 +33,21 @@ spec:
         securityContext:
         {{- if (not .Values.ebpfTopoColl.ebpfTopoColl.containerSecurityContext) }}
           allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
           capabilities:
             drop:
               - ALL
             add:
               - NET_ADMIN
               - SYS_RESOURCE
-              - SYS_PTRACE
-              - DAC_READ_SEARCH
           {{- if .Values.ebpfTopoColl.ebpfTopoColl.useSysAdminCap }}
               - SYS_ADMIN
           {{- else }}
               - BPF
               - PERFMON
           {{- end }}
+          privileged: false
+          runAsUser: 0
+          runAsGroup: 0
         {{- else }}
           {{- toYaml .Values.ebpfTopoColl.ebpfTopoColl.containerSecurityContext
             | nindent 10 }}

--- a/charts/ciroos-agents/values.yaml
+++ b/charts/ciroos-agents/values.yaml
@@ -55,12 +55,6 @@ ebpfTopoColl:
     containerSecurityContext:
   enabled: true
   podSecurityContext:
-    runAsUser: 1000
-    runAsGroup: 1000
-    fsGroup: 1000
-    runAsNonRoot: true
-    seccompProfile:
-      type: Unconfined  # eBPF requires bpf() and perf_event_open() syscalls blocked by RuntimeDefault
 ebpfTopoReducer:
   ebpfTopoReducer:
     image:


### PR DESCRIPTION
## Description

ciroos-agents: update the chart for ebpf-topo-coll service.
Essentially bring the container security context back to original shape[1].

--
[1] https://github.com/ciroos-ai/helm-charts/blob/ac21b6f3f664db167046f90c2c9517d5e1db002d/charts/ciroos-agents/templates/daemonset.yaml

## Testing

- lint
```
helm lint charts/ciroos-agents
==> Linting charts/ciroos-agents
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
```

- local install without error and the service comes up
```
helm upgrade --install ciroos-agent charts/ciroos-agents -n ciroos-agent -f ~/gaurav-kind-3c2w.values
Release "ciroos-agent" has been upgraded. Happy Helming!
NAME: ciroos-agent
LAST DEPLOYED: Thu Apr 30 19:45:44 2026
NAMESPACE: ciroos-agent
STATUS: deployed
REVISION: 4
TEST SUITE: None
```