### PR TITLE
ciros-agents: update chart to add a volume to Beacon and default image.

### DIFF
--- a/charts/ciroos-agents/Chart.yaml
+++ b/charts/ciroos-agents/Chart.yaml
@@ -4,6 +4,6 @@ description: Deploys the Ciroos observability agent into your Kubernetes cluster
 
 type: application
 
-version: 0.3.9
+version: 0.3.10
 
 appVersion: "0.3.0"

--- a/charts/ciroos-agents/templates/deployment.yaml
+++ b/charts/ciroos-agents/templates/deployment.yaml
@@ -72,6 +72,8 @@ spec:
         - mountPath: /etc/certs
           name: ciroos-agent-cert
           readOnly: true
+        - name: data-dir
+          mountPath: /data
       imagePullSecrets:
       - name: regcred
       securityContext: {{- toYaml .Values.beacon.podSecurityContext | nindent
@@ -82,6 +84,8 @@ spec:
         secret:
           defaultMode: 420
           secretName: {{ .Values.clusterName }}-client-cert
+      - name: data-dir
+        emptyDir: {}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/ciroos-agents/values.yaml
+++ b/charts/ciroos-agents/values.yaml
@@ -12,7 +12,7 @@ beacon:
   beacon:
     image:
       repository: registry.ciroos.ai/netra/beacon
-      tag: d5f02432f-013b59ff0-260427T2309Z
+      tag: 0a6f5d0f0-2f9951298-260521T1542Z
     resources:
       limits:
         cpu: 250m


### PR DESCRIPTION
## Description

ciros-agents: update chart to add a volume to Beacon and default image.

## Testing

```
❯ helm lint charts/ciroos-agents

==> Linting charts/ciroos-agents
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed
```

---

```
❯ helm upgrade --install ciroos-agent charts/ciroos-agents -n ciroos-agent -f ~/gaurav-dev-kind-2c1w.values

❯ helm list -A -o yaml
- app_version: 0.3.0
  chart: ciroos-agents-0.3.10
  name: ciroos-agent
  namespace: ciroos-agent
  revision: "4"
  status: deployed
  updated: 2026-05-22 00:55:18.282456422 +0000 UTC
```